### PR TITLE
Added rebootless system update version functions

### DIFF
--- a/src/core/hle/service/set/set_sys.cpp
+++ b/src/core/hle/service/set/set_sys.cpp
@@ -20,7 +20,7 @@
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/ipc_helpers.h"
 #include "core/hle/service/set/set.h"
-#include "core/hle/service/set/set_sys.h"
+#include "core/hle/service/set/settings_types.h"
 
 namespace Service::Set {
 
@@ -789,8 +789,9 @@ void SET_SYS::GetKeyboardLayout(HLERequestContext& ctx) {
 void SET_SYS::GetRebootlessSystemUpdateVersion(HLERequestContext& ctx) {
     LOG_WARNING(Service_SET, "(STUBBED) called.");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);
+    rb.PushRaw<RebootlessSystemUpdateVersion>(m_system_settings.rebootless_system_version);
 }
 
 void SET_SYS::GetDeviceTimeZoneLocationUpdatedTime(HLERequestContext& ctx) {

--- a/src/core/hle/service/set/setting_formats/system_settings.cpp
+++ b/src/core/hle/service/set/setting_formats/system_settings.cpp
@@ -12,6 +12,8 @@ SystemSettings DefaultSystemSettings() {
     settings.version = 0x140000;
     settings.flags = 7;
 
+    settings.rebootless_system_version = {.version = 38, .reserved = 1, .display_version = 38};
+
     settings.mii_author_id = Common::UUID::MakeDefault();
 
     settings.color_set_id = ColorSet::BasicWhite;

--- a/src/core/hle/service/set/setting_formats/system_settings.h
+++ b/src/core/hle/service/set/setting_formats/system_settings.h
@@ -327,6 +327,8 @@ struct SystemSettings {
 
     // nn::settings::system::NxControllerSettings
     std::array<std::array<u8, 0x800>, 10> nx_controller_settings_data_from_offset_30;
+
+    RebootlessSystemUpdateVersion rebootless_system_version;
 };
 
 static_assert(offsetof(SystemSettings, language_code) == 0x10);
@@ -384,7 +386,7 @@ static_assert(offsetof(SystemSettings, device_nick_name) == 0x2A950);
 static_assert(offsetof(SystemSettings, bluetooth_device_settings_last_14) == 0x2AAA0);
 static_assert(offsetof(SystemSettings, nx_controller_settings_data_from_offset_30) == 0x2E6A0);
 
-static_assert(sizeof(SystemSettings) == 0x336A0, "SystemSettings has the wrong size!");
+static_assert(sizeof(SystemSettings) == 0x336E0, "SystemSettings has the wrong size!");
 
 SystemSettings DefaultSystemSettings();
 

--- a/src/core/hle/service/set/settings_types.h
+++ b/src/core/hle/service/set/settings_types.h
@@ -501,4 +501,11 @@ struct TvSettings {
 };
 static_assert(sizeof(TvSettings) == 0x20, "TvSettings is an invalid size");
 
+// https://github.com/switchbrew/libnx/blob/master/nx/include/switch/services/set.h#L714-L719
+struct RebootlessSystemUpdateVersion {
+    u32 version;
+    u8 reserved[0x1C];
+    char display_version[0x20];
+};
+
 } // namespace Service::Set

--- a/src/core/hle/service/set/system_settings.cpp
+++ b/src/core/hle/service/set/system_settings.cpp
@@ -11,6 +11,8 @@ SystemSettings DefaultSystemSettings() {
     settings.version = 0x140000;
     settings.flags = 7;
 
+    settings.rebootless_system_version = {.version = 38, .reserved = 1, .display_version = 38};
+
     settings.color_set_id = ColorSet::BasicWhite;
 
     settings.notification_settings = {

--- a/src/core/hle/service/set/system_settings.h
+++ b/src/core/hle/service/set/system_settings.h
@@ -274,6 +274,15 @@ struct EulaVersion {
 };
 static_assert(sizeof(EulaVersion) == 0x30, "EulaVersion is incorrect size");
 
+// https://github.com/switchbrew/libnx/blob/master/nx/include/switch/services/set.h#L714-L719
+struct RebootlessSystemUpdateVersion {
+    u32 version;
+    u8 reserved[0x1C];
+    char display_version[0x20];
+};
+static_assert(sizeof(RebootlessSystemUpdateVersion) == 0x40,
+              "RebootlessSystemUpdateVersion is incorrect size");
+
 struct SystemSettings {
     // 0/unwritten (1.0.0), 0x20000 (2.0.0), 0x30000 (3.0.0-3.0.1), 0x40001 (4.0.0-4.1.0), 0x50000
     // (5.0.0-5.1.0), 0x60000 (6.0.0-6.2.0), 0x70000 (7.0.0), 0x80000 (8.0.0-8.1.1), 0x90000
@@ -635,6 +644,8 @@ struct SystemSettings {
 
     // nn::settings::system::NxControllerSettings
     std::array<std::array<u8, 0x800>, 10> nx_controller_settings_data_from_offset_30;
+
+    RebootlessSystemUpdateVersion rebootless_system_version;
 };
 
 static_assert(offsetof(SystemSettings, language_code) == 0x10);
@@ -692,7 +703,7 @@ static_assert(offsetof(SystemSettings, device_nick_name) == 0x2A950);
 static_assert(offsetof(SystemSettings, bluetooth_device_settings_last_14) == 0x2AAA0);
 static_assert(offsetof(SystemSettings, nx_controller_settings_data_from_offset_30) == 0x2E6A0);
 
-static_assert(sizeof(SystemSettings) == 0x336A0, "SystemSettings has the wrong size!");
+static_assert(sizeof(SystemSettings) == 0x336E0, "SystemSettings has the wrong size!");
 
 SystemSettings DefaultSystemSettings();
 

--- a/src/core/hle/service/set/system_settings_server.cpp
+++ b/src/core/hle/service/set/system_settings_server.cpp
@@ -1198,8 +1198,11 @@ Result ISystemSettingsServer::SetKeyboardLayout(KeyboardLayout keyboard_layout) 
     R_SUCCEED();
 }
 
-Result ISystemSettingsServer::GetRebootlessSystemUpdateVersion() {
-    LOG_WARNING(Service_SET, "(STUBBED) called.");
+Result ISystemSettingsServer::GetRebootlessSystemUpdateVersion(
+    Out<RebootlessSystemUpdateVersion> out_rebootless_update_version) {
+    LOG_INFO(Service_SET, "called");
+
+    *out_rebootless_update_version = m_system_settings.rebootless_system_version;
     R_SUCCEED();
 }
 

--- a/src/core/hle/service/set/system_settings_server.h
+++ b/src/core/hle/service/set/system_settings_server.h
@@ -136,7 +136,8 @@ public:
     Result SetAppletLaunchFlags(u32 applet_launch_flag);
     Result GetKeyboardLayout(Out<KeyboardLayout> out_keyboard_layout);
     Result SetKeyboardLayout(KeyboardLayout keyboard_layout);
-    Result GetRebootlessSystemUpdateVersion();
+    Result GetRebootlessSystemUpdateVersion(
+        Out<RebootlessSystemUpdateVersion> out_rebootless_update_version);
     Result GetDeviceTimeZoneLocationUpdatedTime(
         Out<Service::PSC::Time::SteadyClockTimePoint> out_time_point);
     Result SetDeviceTimeZoneLocationUpdatedTime(


### PR DESCRIPTION
Fixes an issue where Support/Health and Safety would crash and freeze the emulation (0x2A2 iirc) when selected in the settings menu